### PR TITLE
oome_monitor default oome_file name change

### DIFF
--- a/docs/oome_monitor.rst
+++ b/docs/oome_monitor.rst
@@ -17,8 +17,7 @@ creates an ".oome" file when out of memory conditions are met, e.g.:
 the following:
 * If its provided as an argument - use that
 * $OOME_FILE environment variable of the process
-* $HOMEDIR environment variable and the process name + .oome
-* $CWD of the process and the process name + .oome
+* $CWD of the process + /work/oome
   
 :command:`oome_monitor` could be run to monitor all supervisord processes or
 specified ones inside the configuration file. In case if only one process is

--- a/superlance/oome_monitor.py
+++ b/superlance/oome_monitor.py
@@ -68,8 +68,7 @@ class OomeProcess(object):
                     # Otherwise get the process cwd
                     cwd = os.readlink('/proc/{0}/cwd'.format(
                         self.process['pid']))
-                self.oome_file = '{0}/state/{1}.oome'.format(cwd,
-                        self.process['name'])
+                self.oome_file = '{0}/work/oome'.format(cwd)
         return self._oome_file
     
     @oome_file.setter

--- a/superlance/tests/oome_monitor_test.py
+++ b/superlance/tests/oome_monitor_test.py
@@ -62,7 +62,7 @@ class TestOomeProcess(unittest.TestCase):
         """
         self.process._oome_file = None
         self.process._env_vars = {'HOMEDIR': 'homedir'}
-        self.assertEqual('homedir/state/foo.oome', self.process.oome_file)
+        self.assertEqual('homedir/work/oome', self.process.oome_file)
     
     @mock.patch('superlance.oome_monitor.os.readlink')
     def test_get_oome_file_cwd(self, mock_readlink):
@@ -72,7 +72,7 @@ class TestOomeProcess(unittest.TestCase):
         mock_readlink.return_value = 'cwd'
         self.process._oome_file = None
         self.process._env_vars = {'USELESS_VAR': '3.141599'}
-        self.assertEqual('cwd/state/foo.oome', self.process.oome_file)
+        self.assertEqual('cwd/work/oome', self.process.oome_file)
         
     def test_set_oome_file(self):
         """


### PR DESCRIPTION
- Changed the default oome file to point to $CWD/work/oome
